### PR TITLE
Update Composer DAGs for new BigQuery operators

### DIFF
--- a/engineer/airflow/solutions/create_datasets.py
+++ b/engineer/airflow/solutions/create_datasets.py
@@ -1,6 +1,6 @@
 from airflow import DAG
 from datetime import datetime
-from airflow.contrib.operators.bigquery_operator import BigQueryCreateEmptyDatasetOperator
+from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
 
 DATASETS = ['raw', 'optimized', 'views', 'functions', 'models']
 PROJECT = 'your-project-id'


### PR DESCRIPTION
Google has deprecated the BigQuery operators used in the create_datasets and prod_to_bq DAGs. They're now in a new package. I've updated and validated. Also note there are new CreateTable and CreateView operators which should probably be used going forward instead of the generic InsertJob.